### PR TITLE
refactor(core): refactor error system, fix service param, etc

### DIFF
--- a/tasks/ConfigTasks.sh
+++ b/tasks/ConfigTasks.sh
@@ -19,11 +19,9 @@ Task::config(){
 
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  -i inventory playbook.config.yml
+  -i inventory playbook.config.yml || colorize light_red "error: config"
   highlight "Encrypting Secrets in the Vault"
-  Task::run_docker ansible-vault encrypt settings/vault.yml || true
-  highlight "Configuration Complete"
-
+  Task::run_docker ansible-vault encrypt settings/vault.yml || colorize light_red "error: config: encrypt"
 }
 
 #Show the Configuration settings for a given service
@@ -37,7 +35,7 @@ Task::show_config(){
 
 # Resets the local settings
 Task::config_reset() {
-  : @desc "Resets the Configuration"
+  : @desc "Resets VivumLab configs"
   : @param force true "Forces a rebuild/repull of the docker image"
   : @param build true "Forces to build the image locally"
 
@@ -45,7 +43,7 @@ Task::config_reset() {
   Task::build $(build_check) $(force_check)
 
   highlight "Reset Local Settings"
-  echo "First we'll make a backup of your current settings in case you actually need them \n"
+  echo "Backing up your current settings, you may need them \n"
   mv settings settings.bak
   mkdir settings
   Task::config

--- a/tasks/LifecyleTasks.sh
+++ b/tasks/LifecyleTasks.sh
@@ -2,7 +2,7 @@
 
 # Main deployment task - used to deploy VLAB
 Task::deploy(){
-  : @desc "Main deployment task - used to deploy VLAB"
+  : @desc "Main deployment task - deploys VivumLab"
   : @param config_dir="settings"
   : @param force true "Forces a rebuild/repull of the docker image"
   : @param build true "Forces to build the image locally"
@@ -14,16 +14,9 @@ Task::deploy(){
   Task::build $(build_check) $(force_check)
 
   highlight "Deploying VivumLab"
-  if [[ ${_debug-false} == true ]] ; then
-    Task::run_docker ansible-playbook $(debug_check) \
-    --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-    -i inventory playbook.vivumlab.yml
-  else
-    Task::run_docker ansible-playbook $(debug_check) \
-    --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-    -i inventory playbook.vivumlab.yml
-
-  fi
+  Task::run_docker ansible-playbook $(debug_check) \
+  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  -i inventory playbook.vivumlab.yml || colorize light_red "error: deploy"
 }
 
 # Restart All Enabled services
@@ -39,28 +32,27 @@ Task::restart(){
   Task::git_sync
   Task::config
 
-  highlight "Stopping all services"
+  highlight "Restarting all services"
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  -i inventory playbook.restart.yml
-  highlight "Services restarting"
+  -i inventory playbook.restart.yml || colorize light_red "error: restart"
 }
 
 # Restart the selected service
 Task::restart_one(){
   : @desc "Restarts the specified service"
-  : @param service "Service Name"
+  : @param service! "Service Name"
   : @param config_dir="settings"
   : @param debug true "Debugs ansible-playbook commands"
 
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.restart.yml
+  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.restart.yml || colorize light_red "error: restart_one"
 }
 
 # Stop All Enabled services
 Task::stop(){
-  : @desc "Restart all enabled services"
+  : @desc "Stops all enabled services"
   : @param config_dir="settings"
   : @param force true "Forces a rebuild/repull of the docker image"
   : @param build true "Forces to build the image locally"
@@ -74,14 +66,13 @@ Task::stop(){
   highlight "Stopping all services"
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  -i inventory playbook.stop.yml
-  highlight "Services restarting"
+  -i inventory playbook.stop.yml || colorize light_red "error: stop"
 }
 
 # Stop the selected service
 Task::stop_one(){
-  : @desc "Restarts the specified service"
-  : @param service "Service Name"
+  : @desc "Stops the specified service"
+  : @param service! "Service Name"
   : @param config_dir="settings"
   : @param force true "Forces a rebuild/repull of the docker image"
   : @param build true "Forces to build the image locally"
@@ -94,13 +85,13 @@ Task::stop_one(){
 
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml
+  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml  || colorize light_red "error: stop_one"
 }
 
 # Removes One Service
 Task::remove_one(){
-  : @desc "Removes the specified service on the VivumLab server"
-  : @param service "Service Name"
+  : @desc "Removes the specified service from the VivumLab server"
+  : @param service! "Service Name"
   : @param config_dir="settings"
   : @param force true "Forces a rebuild/repull of the docker image"
   : @param build true "Forces to build the image locally"
@@ -114,14 +105,13 @@ Task::remove_one(){
   highlight "Removing data for ${_service}"
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml
-  highlight "Removal Complete"
+  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml || colorize light_red "error: remove_one"
 }
 
 # Resets a services' data files
 Task::reset_one(){
-  : @desc "Resets the specified service' files on the VivumLab server"
-  : @param service "Service Name"
+  : @desc "Resets the specified services' files from the VivumLab server"
+  : @param service! "Service Name"
   : @param config_dir="settings"
   : @param force true "Forces a rebuild/repull of the docker image"
   : @param build true "Forces to build the image locally"
@@ -135,13 +125,12 @@ Task::reset_one(){
   highlight "Resetting ${_service}"
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml
+  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml || colorize light_red "error: reset_one: stop"
 	Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml
+  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml  || colorize light_red "error: reset_one: remove"
 	highlight "Redeploying ${_service}"
 	Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  --extra-vars='{"services":["'${_service}'"]}' -i inventory -t deploy playbook.vivumlab.yml
-	highlight "Done resetting ${_service}"
+  --extra-vars='{"services":["'${_service}'"]}' -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: reset_one: deploy"
 }

--- a/tasks/LifecyleTasks.sh
+++ b/tasks/LifecyleTasks.sh
@@ -17,6 +17,7 @@ Task::deploy(){
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   -i inventory playbook.vivumlab.yml || colorize light_red "error: deploy"
+  
 }
 
 # Restart All Enabled services
@@ -36,6 +37,7 @@ Task::restart(){
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   -i inventory playbook.restart.yml || colorize light_red "error: restart"
+  highlight "Services restarted"
 }
 
 # Restart the selected service
@@ -48,6 +50,7 @@ Task::restart_one(){
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.restart.yml || colorize light_red "error: restart_one"
+  highlight "Restarted ${_service}"
 }
 
 # Stop All Enabled services
@@ -67,6 +70,7 @@ Task::stop(){
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   -i inventory playbook.stop.yml || colorize light_red "error: stop"
+  highlight "Services stopped"
 }
 
 # Stop the selected service
@@ -86,6 +90,7 @@ Task::stop_one(){
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml  || colorize light_red "error: stop_one"
+  highlight "Stopped ${_service}"
 }
 
 # Removes One Service
@@ -106,7 +111,7 @@ Task::remove_one(){
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml || colorize light_red "error: remove_one"
-}
+  highlight "Removed $"{_service}"
 
 # Resets a services' data files
 Task::reset_one(){
@@ -126,11 +131,12 @@ Task::reset_one(){
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml || colorize light_red "error: reset_one: stop"
-	Task::run_docker ansible-playbook $(debug_check) \
+  Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml  || colorize light_red "error: reset_one: remove"
-	highlight "Redeploying ${_service}"
-	Task::run_docker ansible-playbook $(debug_check) \
+  highlight "Redeploying ${_service}"
+  Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: reset_one: deploy"
+  highlight "Reset ${_service}"
 }

--- a/tasks/LifecyleTasks.sh
+++ b/tasks/LifecyleTasks.sh
@@ -17,7 +17,6 @@ Task::deploy(){
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
   -i inventory playbook.vivumlab.yml || colorize light_red "error: deploy"
-  
 }
 
 # Restart All Enabled services

--- a/tasks/SanityCheckTasks.sh
+++ b/tasks/SanityCheckTasks.sh
@@ -42,9 +42,9 @@ Task::check_for_settings(){
         colorize light_red "Creating an empty Vault"
         echo "blank_on_purpose: True" > settings/vault.yml
     fi
-    if [[ ! -f tasks/Vars ]]; then
-      colorize light_red "error: settings_exist: Vars file missing. Creating.."
-      echo "blank_on_purpose: True" > tasks/Vars
+    if [[ ! -f tasks/ansible_bash.vars ]]; then
+      colorize light_red "Creating ansible_bash.vars file"
+      echo "blank_on_purpose: True" > tasks/ansible_bash.vars
     fi
 }
 

--- a/tasks/SanityCheckTasks.sh
+++ b/tasks/SanityCheckTasks.sh
@@ -26,22 +26,25 @@ Task::check_for_settings(){
     mkdir -p settings/passwords
     [ -f ~/.vlab_vault_pass ] || Task::generate_ansible_pass
 
-    if ! [[ -d settings ]]; then
-        colorize red "Seems to be your first time running this."
+    if [[ ! -d settings ]]; then
         colorize light_red "Creating settings directory"
         mkdir -p settings
     fi
-    if  ! [[ -d settings/passwords ]]; then
+    if  [[ ! -d settings/passwords ]]; then
         colorize light_red "Creating passwords directory"
         mkdir -p settings/passwords
     fi
-    if ! [[ -f settings/config.yml ]]; then
+    if [[ ! -f settings/config.yml ]]; then
         colorize light_red "Creating an empty config file"
         echo "blank_on_purpose: True" > settings/config.yml
     fi
-    if ! [[ -f settings/vault.yml ]]; then
+    if [[ ! -f settings/vault.yml ]]; then
         colorize light_red "Creating an empty Vault"
         echo "blank_on_purpose: True" > settings/vault.yml
+    fi
+    if [[ ! -f tasks/Vars ]]; then
+      colorize light_red "error: settings_exist: Vars file missing. Creating.."
+      echo "blank_on_purpose: True" > tasks/Vars
     fi
 }
 

--- a/tasks/TerraformTasks.sh
+++ b/tasks/TerraformTasks.sh
@@ -18,7 +18,7 @@ Task::terraform(){
   # Generate Terraform files
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  -i inventory playbook.terraform.yml
+  -i inventory playbook.terraform.yml || colorize light_red "error: terraform: deploy"
 
   # Run terraform
   # If we send multiple commands to the docker container (/bin/bash -c), we can "cd" into the "settings" directory
@@ -39,6 +39,7 @@ Task::terraform_destroy(){
   : @param config_dir="settings"
 
   highlight "Destroying cloud servers"
-  Task::run_docker /bin/bash -c "cd $_config_dir; terraform destroy"
+  Task::run_docker /bin/bash -c "cd $_config_dir; terraform destroy" \
+  || "error: terraform_destroy"
   highlight "Cloud Servers destroyed"
 }

--- a/tasks/UpdateTasks.sh
+++ b/tasks/UpdateTasks.sh
@@ -13,20 +13,20 @@ Task::update() {
   Task::git_sync
   Task::config
 
-  highlight "Updating VivumLab Services using $_config_dir"
+  highlight "Updating VivumLab Services"
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  -i inventory -t deploy playbook.vivumlab.yml
+  -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: update"
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  -i inventory playbook.restart.yml
-  highlight "Update Complete"
+  -i inventory playbook.restart.yml || colorize light_red "error: update: restart"
+  highlight "Services Updated"
 }
 
 # Updates the specified service on the VivumLab server
 Task::update_one(){
   : @desc "Updates the specified service on the VivumLab server"
-  : @param service "Service Name"
+  : @param service! "Service Name"
   : @param config_dir="settings"
   : @param force true "Forces a rebuild/repull of the docker image"
   : @param build true "Forces to build the image locally"
@@ -39,9 +39,10 @@ Task::update_one(){
   Task::config
 
   Task::run_docker ansible-playbook $(debug_check) \
-  --extra-vars='{"services":["'${_service}'"]}' --extra-vars="@$_config_dir/config.yml" \
-  --extra-vars="@$_config_dir/vault.yml" -i inventory -t deploy playbook.vivumlab.yml
+  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars='{"services":["'${_service}'"]}' -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: update_one"
   Task::run_docker ansible-playbook $(debug_check) \
-  --extra-vars='{"services":["'${_service}'"]}' --extra-vars="@$_config_dir/config.yml" \
-  --extra-vars="@$_config_dir/vault.yml" -i inventory playbook.restart.yml
+  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.restart.yml || colorize light_red "error: update_one: restart"
+  highlight "$_service Updated"
 }

--- a/tasks/vlabTasks.sh
+++ b/tasks/vlabTasks.sh
@@ -103,7 +103,7 @@ Task::encrypt(){
   highlight "Encrypting Vault"
     local userID=$(id -u)
     local groupID=$(id -g)
-  Task::run_docker ansible-vault encrypt settings/vault.yml
+  Task::run_docker ansible-vault encrypt settings/vault.yml  || colorize light_red "error: encrypt"
   sudo chmod 640 settings/vault.yml
   sudo chown $userID:$groupID settings/vault.yml
   highlight "Vault encrypted!"
@@ -116,7 +116,7 @@ Task::decrypt(){
   highlight "Decrypting Vault"
     local userID=$(id -u)
     local groupID=$(id -g)
-  Task::run_docker ansible-vault decrypt settings/vault.yml || true
+  Task::run_docker ansible-vault decrypt settings/vault.yml || colorize light_red "error: decrypt"
   sudo chmod 640 settings/vault.yml
   sudo chown $userID:$groupID settings/vault.yml
   highlight "Vault decrypted!"
@@ -136,7 +136,7 @@ Task::uninstall(){
   highlight "Uninstall VivumLab Completely"
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  -i inventory -t deploy playbook.remove.yml
+  -i inventory -t deploy playbook.remove.yml || colorize light_red "error: uninstall"
   highlight "Uninstall Complete"
 }
 
@@ -148,7 +148,7 @@ Task::restore() {
 
   Task::run_docker ansible-playbook $(debug_check) \
   --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
-  -i inventory restore.yml
+  -i inventory restore.yml  || colorize light_red "error: restore"
 }
 
 # Opens a shell in the VivumLab deploy container
@@ -163,7 +163,7 @@ Task::track(){
   : @desc "Switches you to the specified branch or tag. use branch=<branchname>"
   : @param branch! "Required! Branch or tag name to track"
 
-  git checkout $_branch
+  git checkout $_branch || colorize light_red "error: track: $_branch"
 }
 
 Task::run_docker() {


### PR DESCRIPTION
couple of things were added/fixed:

- added/ refactored error system... made more universal??..: essentially, now when a task initiates an ansible playbook command and it fails, there is no more multiline errors with insane line numbers. It just says 'error: <task>: <part of task (if applicable)>'

- added an exclaimation mark to the service params, this makes the service param a requirement (for the applicable playbook commands)

- made some user communication more concise.. terminal text can get pretty fast, VivumLab should get the point across quick

- got rid of some redundant code in the deploy task, that I forgot to remove earlier

- the stop and stop_one tasks had an errorneous description (said 'restart' instead of 'stop')

- put the exclamation mark inside the bash if conditional brackets (config task).. this is best practise, apparently

- added the creation of the 'ansible_bash.vars' file to the config task